### PR TITLE
Further support for 64-bit AT&T syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.12
+Further support for 64-bit AT&T syntax
+* q and w postfix for mov, cmp, push, pop etc.
+* support for the datatypes quad and space
+* support global labels
+* support for integer counterparts of div and mul
+
 ## 2.2.11
 Better support for datatypes
 * signed types (non-nasm)

--- a/grammars/x86_64 assembly.cson
+++ b/grammars/x86_64 assembly.cson
@@ -84,7 +84,7 @@ repository:
   entities:
     patterns: [
       {
-        match: "((section|segment)\\s+)?\\.((ro)?data|bss|text)"
+        match: "((section|segment)\\s+)?\\.((ro)?data|bss|text|global)"
         name: "entity.name.section"
       }
       {
@@ -184,7 +184,7 @@ repository:
       }
     ]
   "mnemonics-64bit":
-    match: "\\b(cdqe|cqo|(cmp|lod|mov|sto)sq|cmpxchg16b|mov(ntq|sxd)|scasq|swapgs|sys(call|ret))\\b"
+    match: "\\b(cdqe|cqo|(cmp|lod|mov|sto)s?q|cmpxchg16b|mov(ntq|sxd|zb[wq]?)|scasq|swapgs|sys(call|ret))\\b"
     name: "keyword.mnemonic.64-bit-mode"
   "mnemonics-aesni":
     match: "\\b(aes((dec|enc)(last)?|imc|keygenassist)|pclmulqdq)\\b"
@@ -220,7 +220,7 @@ repository:
         name: "keyword.mnemonic.avx.promoted.mov"
       }
       {
-        match: "\\b(v((add|div|mul|sub|max|min|round|sqrt)[ps][ds]|(addsub|dp)p[ds]|(rcp|rsqrt)[ps]s))\\b"
+        match: "\\b(v((add|i?div|i?mul|sub|max|min|round|sqrt)[ps][ds]|(addsub|dp)p[ds]|(rcp|rsqrt)[ps]s))\\b"
         name: "keyword.mnemonic.avx.promoted.packed-arithmetic"
       }
       {
@@ -440,11 +440,11 @@ repository:
         name: "keyword.mnemonic.general-purpose.data-transfer.xchg"
       }
       {
-        match: "\\b((push|pop)(ad?)?|cwde?|cdq|cbw)\\b"
+        match: "\\b((push|pop)(ad?)?|cwde?|cdq|cbw|(push|pop)[wq])\\b"
         name: "keyword.mnemonic.general-purpose.data-transfer.other"
       }
       {
-        match: "\\b(adcx?|adox|add|sub|sbb|i?mul|i?div|inc|dec|neg|cmp)\\b"
+        match: "\\b(adcx?|adox|add|sub|sbb|i?mul|i?div|inc|dec|neg|cmp)[wq]?\\b"
         name: "keyword.mnemonic.general-purpose.binary-arithmetic"
       }
       {
@@ -1025,7 +1025,7 @@ repository:
   support:
     patterns: [
       {
-        match: "(?i)\\b(s?byte|([doqtyz]|dq|s[dq]?)?word|(d|res)[bdoqtwyz]?|ddq|incbin|equ|times|(end|i)?struc|at|iend)\\b"
+        match: "(?i)\\b(s?byte|([doqtyz]|dq|s[dq]?)?word|(d|res)[bdoqtwyz]?|ddq|incbin|equ|times|(end|i)?struc|at|iend|quad|space)\\b"
         name: "support.type.asm"
       }
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-x86-64-assembly",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "description": "Bleeding edge x86 and x86_64 assembly syntax",
   "keywords": [],
   "repository": "https://github.com/13xforever/language-x86_64-assembly",


### PR DESCRIPTION
Further support for 64-bit AT&T syntax
* q and w postfix for mov, cmp, push, pop etc.
* support for the datatypes quad and space
* support global labels
* support for integer counterparts of div and mul

I believe that the difference is best shown by example, therefore I've prepared a file where the differences can easily be seen: https://gist.github.com/AlexGustafsson/fb85f9107ffde7fe77966fb02f29501b

I would like an opinion on how to handle global labels. Right now they're added as an `entity.name.section` which may or may not be appropriate. What do you think?